### PR TITLE
package import name matching

### DIFF
--- a/example_2.py
+++ b/example_2.py
@@ -3,8 +3,8 @@
 # in the Metric unit system
 
 import numpy as np
-from pyCUFSM.fsm import strip
-from pyCUFSM.preprocess import stress_gen
+from pysufsm.fsm import strip
+from pycufsm.preprocess import stress_gen
 
 
 def __main__():


### PR DESCRIPTION
since the package is installed on system with lower case letters, the example is edited to match such naming to prevent import package errors for this example.