### PR TITLE
New, simpler input format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,9 +32,9 @@ jobs:
       - name: Run formatting checks with YAPF
         run: |
           yapf --diff --verbose --recursive .
-      # - name: Run type checks with mypy
-      #   run: |
-      #     mypy
+      - name: Run type checks with mypy
+        run: |
+          mypy
       - name: Run FEM tests with pytest
         run: |
           python -m pytest --pspec tests/

--- a/pycufsm/analysis_c.pyx
+++ b/pycufsm/analysis_c.pyx
@@ -62,68 +62,6 @@ cpdef int constr_bc_flag(np.ndarray nodes, np.ndarray constraints):
         return 1
 
 
-cpdef np.ndarray addspring(
-    np.ndarray k_global, np.ndarray springs, int n_nodes, double length, str b_c,
-    np.ndarray m_a
-):
-    """Add spring stiffness to global elastic stiffness matrix
-
-    Args:
-        k_global (np.ndarray): complete elastic stiffness matrix
-        springs (np.ndarray): [node# DOF(x=1,y=2,z=3,theta=4) k_s]
-            definition of any external springs added to the member
-        n_nodes (int): _description_
-        length (float): _description_
-        b_c (str): _description_
-        m_a (np.ndarray): _description_
-
-    Returns:
-        np.ndarray: _description_
-    
-    BWS, August 2000
-    modified by Z. Li, Aug. 09, 2009 for general B.C.
-    Z. Li, June 2010
-    """
-    if len(springs) > 0:
-        total_m = len(m_a)  # Total number of longitudinal terms m
-
-        for spring in springs:
-            node = spring[0]
-            dof = spring[1]
-            k_stiff = spring[2]
-            k_flag = spring[3]
-
-            if dof == 1:
-                r_c = 2*node - 1
-            elif dof == 2:
-                r_c = 2*n_nodes + 2*node - 1
-            elif dof == 3:
-                r_c = 2 * node
-            elif dof == 4:
-                r_c = 2*n_nodes + 2*node
-            else:
-                r_c = 1
-                k_s = 0
-
-            for i in range(0, total_m):
-                for j in range(0, total_m):
-                    if k_flag == 0:
-                        k_s = k_stiff  # k_stiff is the total stiffness and may be added directly
-                    else:
-                        if dof == 3:
-                            k_s = 0  # axial dof with a foundation stiffness has no net stiffness
-                        else:
-                            [i_1, _, _, _, _] = bc_i1_5(b_c, m_a[i], m_a[j], length)
-                            k_s = k_stiff * i_1
-                            # k_stiff is a foundation stiffness and an equivalent
-                            # total stiffness must be calculated
-
-                    k_global[4*n_nodes*i+r_c-1, 4*n_nodes*j+r_c-1] \
-                        = k_global[4*n_nodes*i+r_c-1, 4*n_nodes*j+r_c-1] + k_s
-
-    return k_global
-
-
 cpdef np.ndarray elem_prop(np.ndarray nodes, np.ndarray elements):
     """creates a matrix of element properties for each element (width and slope)
 

--- a/pycufsm/analysis_c.pyx
+++ b/pycufsm/analysis_c.pyx
@@ -1340,7 +1340,7 @@ cpdef np.ndarray spring_assemble(
 
             k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2,
                      4*n_nodes*j + (node_i+1) * 2 - 1:4*n_nodes*j + (node_i+1) * 2] += k11
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2,
                          4*n_nodes*j + (node_j+1) * 2 - 1:4*n_nodes*j + (node_j+1) * 2] += k12
                 k_global[4*n_nodes*i + (node_j+1) * 2 - 1:4*n_nodes*i + (node_j+1) * 2,
@@ -1351,7 +1351,7 @@ cpdef np.ndarray spring_assemble(
             k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip + (node_i+1) * 2,
                      4*n_nodes*j + skip + (node_i+1) * 2 - 1:4*n_nodes*j + skip
                      + (node_i+1) * 2] += k33
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip
                          + (node_i+1) * 2, 4*n_nodes*j + skip + (node_j+1) * 2 - 1:4*n_nodes*j
                          + skip + (node_j+1) * 2] += k34
@@ -1364,7 +1364,7 @@ cpdef np.ndarray spring_assemble(
 
             k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2, 4*n_nodes*j
                      + skip + (node_i+1) * 2 - 1:4*n_nodes*j + skip + (node_i+1) * 2] += k13
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2, 4*n_nodes*j
                          + skip + (node_j+1) * 2 - 1:4*n_nodes*j + skip + (node_j+1) * 2] += k14
                 k_global[4*n_nodes*i + (node_j+1) * 2 - 1:4*n_nodes*i + (node_j+1) * 2, 4*n_nodes*j
@@ -1374,7 +1374,7 @@ cpdef np.ndarray spring_assemble(
 
             k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip + (node_i+1) * 2,
                      4*n_nodes*j + (node_i+1) * 2 - 1:4*n_nodes*j + (node_i+1) * 2] += k31
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip
                          + (node_i+1) * 2,
                          4*n_nodes*j + (node_j+1) * 2 - 1:4*n_nodes*j + (node_j+1) * 2] += k32

--- a/pycufsm/analysis_p.py
+++ b/pycufsm/analysis_p.py
@@ -55,68 +55,6 @@ def constr_bc_flag(nodes: np.ndarray, constraints: np.ndarray) -> int:
         return 1
 
 
-def addspring(
-    k_global: np.ndarray, springs: np.ndarray, n_nodes: int, length: float, b_c: str,
-    m_a: np.ndarray
-) -> np.ndarray:
-    """Add spring stiffness to global elastic stiffness matrix
-
-    Args:
-        k_global (np.ndarray): complete elastic stiffness matrix
-        springs (np.ndarray): [node# DOF(x=1,y=2,z=3,theta=4) k_s]
-            definition of any external springs added to the member
-        n_nodes (int): _description_
-        length (float): _description_
-        b_c (str): _description_
-        m_a (np.ndarray): _description_
-
-    Returns:
-        np.ndarray: _description_
-    
-    BWS, August 2000
-    modified by Z. Li, Aug. 09, 2009 for general B.C.
-    Z. Li, June 2010
-    """
-    if len(springs) > 0:
-        total_m = len(m_a)  # Total number of longitudinal terms m
-
-        for spring in springs:
-            node = spring[0]
-            dof = spring[1]
-            k_stiff = spring[2]
-            k_flag = spring[3]
-
-            if dof == 1:
-                r_c = 2*node - 1
-            elif dof == 2:
-                r_c = 2*n_nodes + 2*node - 1
-            elif dof == 3:
-                r_c = 2 * node
-            elif dof == 4:
-                r_c = 2*n_nodes + 2*node
-            else:
-                r_c = 1
-                k_s = 0
-
-            for i in range(0, total_m):
-                for j in range(0, total_m):
-                    if k_flag == 0:
-                        k_s = k_stiff  # k_stiff is the total stiffness and may be added directly
-                    else:
-                        if dof == 3:
-                            k_s = 0  # axial dof with a foundation stiffness has no net stiffness
-                        else:
-                            [i_1, _, _, _, _] = bc_i1_5(b_c, m_a[i], m_a[j], length)
-                            k_s = k_stiff * i_1
-                            # k_stiff is a foundation stiffness and an equivalent
-                            # total stiffness must be calculated
-
-                    k_global[4*n_nodes*i+r_c-1, 4*n_nodes*j+r_c-1] \
-                        = k_global[4*n_nodes*i+r_c-1, 4*n_nodes*j+r_c-1] + k_s
-
-    return k_global
-
-
 def elem_prop(nodes: np.ndarray, elements: np.ndarray) -> np.ndarray:
     """creates a matrix of element properties for each element (width and slope)
 

--- a/pycufsm/analysis_p.py
+++ b/pycufsm/analysis_p.py
@@ -1206,7 +1206,7 @@ def spring_assemble(
 
             k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2,
                      4*n_nodes*j + (node_i+1) * 2 - 1:4*n_nodes*j + (node_i+1) * 2] += k11
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2,
                          4*n_nodes*j + (node_j+1) * 2 - 1:4*n_nodes*j + (node_j+1) * 2] += k12
                 k_global[4*n_nodes*i + (node_j+1) * 2 - 1:4*n_nodes*i + (node_j+1) * 2,
@@ -1217,7 +1217,7 @@ def spring_assemble(
             k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip + (node_i+1) * 2,
                      4*n_nodes*j + skip + (node_i+1) * 2 - 1:4*n_nodes*j + skip
                      + (node_i+1) * 2] += k33
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip
                          + (node_i+1) * 2, 4*n_nodes*j + skip + (node_j+1) * 2 - 1:4*n_nodes*j
                          + skip + (node_j+1) * 2] += k34
@@ -1230,7 +1230,7 @@ def spring_assemble(
 
             k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2, 4*n_nodes*j
                      + skip + (node_i+1) * 2 - 1:4*n_nodes*j + skip + (node_i+1) * 2] += k13
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + (node_i+1) * 2 - 1:4*n_nodes*i + (node_i+1) * 2, 4*n_nodes*j
                          + skip + (node_j+1) * 2 - 1:4*n_nodes*j + skip + (node_j+1) * 2] += k14
                 k_global[4*n_nodes*i + (node_j+1) * 2 - 1:4*n_nodes*i + (node_j+1) * 2, 4*n_nodes*j
@@ -1240,7 +1240,7 @@ def spring_assemble(
 
             k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip + (node_i+1) * 2,
                      4*n_nodes*j + (node_i+1) * 2 - 1:4*n_nodes*j + (node_i+1) * 2] += k31
-            if node_j != 0:
+            if node_j != -1:
                 k_global[4*n_nodes*i + skip + (node_i+1) * 2 - 1:4*n_nodes*i + skip
                          + (node_i+1) * 2,
                          4*n_nodes*j + (node_j+1) * 2 - 1:4*n_nodes*j + (node_j+1) * 2] += k32

--- a/pycufsm/examples/example_1.py
+++ b/pycufsm/examples/example_1.py
@@ -122,6 +122,6 @@ def __main__() -> Dict[str, np.ndarray]:
         'X_values': lengths,
         'Y_values': signature,
         'Y_values_allmodes': curve,
-        'Orig_coords': nodes,
+        'Orig_coords': nodes_p,
         'Deformations': shapes
     }

--- a/pycufsm/examples/example_1.py
+++ b/pycufsm/examples/example_1.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from pycufsm.fsm import strip
 from pycufsm.preprocess import stress_gen
-from pycufsm.types import B_C, GBT_Con, Sect_Props
+from pycufsm.types import BC, GBT_Con, Sect_Props
 
 # This example presents a very simple Cee section,
 # solved for pure compression,
@@ -55,7 +55,7 @@ def __main__() -> Dict[str, np.ndarray]:
     }
 
     # Simply-supported boundary conditions
-    b_c: B_C = 'S-S'
+    b_c: BC = 'S-S'
 
     # For signature curve analysis, only a single array of ones makes sense here
     m_all = np.ones((len(lengths), 1))

--- a/pycufsm/examples/example_1.py
+++ b/pycufsm/examples/example_1.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from pycufsm.fsm import strip
 from pycufsm.preprocess import stress_gen
-from pycufsm.types import GBT_Con, Sect_Props
+from pycufsm.types import B_C, GBT_Con, Sect_Props
 
 # This example presents a very simple Cee section,
 # solved for pure compression,
@@ -55,7 +55,7 @@ def __main__() -> Dict[str, np.ndarray]:
     }
 
     # Simply-supported boundary conditions
-    b_c = 'S-S'
+    b_c: B_C = 'S-S'
 
     # For signature curve analysis, only a single array of ones makes sense here
     m_all = np.ones((len(lengths), 1))
@@ -92,10 +92,11 @@ def __main__() -> Dict[str, np.ndarray]:
             'Mxx': 0,
             'Myy': 0,
             'M11': 0,
-            'M22': 0
+            'M22': 0,
+            'restrain': False,
+            'offset': [-thickness / 2, -thickness / 2]
         },
         sect_props=sect_props,
-        offset_basis=[-thickness / 2, -thickness / 2]
     )
 
     # Perform the Finite Strip Method analysis

--- a/pycufsm/examples/example_1_new.py
+++ b/pycufsm/examples/example_1_new.py
@@ -19,6 +19,12 @@ def __main__() -> Dict[str, np.ndarray]:
     # Nodal location units are inches
     nodes = [[5, 1], [5, 0], [2.5, 0], [0, 0], [0, 3], [0, 6], [0, 9], [2.5, 9], [5, 9], [5, 8]]
     elements: List[New_Element] = [{"nodes": "all", "t": 0.1, "mat": "CFS"}]
+    lengths = np.array([
+        0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4, 4.25, 4.5, 4.75,
+        5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 26, 28, 30, 32, 34, 36,
+        38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120,
+        132, 144, 156, 168, 180, 204, 228, 252, 276, 300
+    ])
 
     # Values here correspond to signature curve basis and orthogonal based upon geometry
     analysis_config: Analysis_Config = {'b_c': "S-S", 'n_eigs': 10}
@@ -49,6 +55,7 @@ def __main__() -> Dict[str, np.ndarray]:
         props=props,
         nodes=nodes,
         elements=elements,
+        lengths=lengths,
         forces={
             'P': sect_props['A'] * 50,
             'Mxx': 0,

--- a/pycufsm/examples/example_1_new.py
+++ b/pycufsm/examples/example_1_new.py
@@ -1,0 +1,75 @@
+from typing import Dict, List
+
+import numpy as np
+
+from pycufsm.fsm import strip_new
+from pycufsm.types import Analysis_Config, New_Element, Sect_Props
+
+# This example presents a very simple Cee section,
+# solved for pure compression,
+# in the Imperial unit system
+
+
+def __main__() -> Dict[str, np.ndarray]:
+    # Define an isotropic material with E = 29,500 ksi and nu = 0.3
+    props = {"CFS": {'E': 29500, 'nu': 0.3}}
+
+    # Define a lightly-meshed Cee shape
+    # (1 element per lip, 2 elements per flange, 3 elements on the web)
+    # Nodal location units are inches
+    nodes = [[5, 1], [5, 0], [2.5, 0], [0, 0], [0, 3], [0, 6], [0, 9], [2.5, 9], [5, 9], [5, 8]]
+    elements: List[New_Element] = [{"nodes": "all", "t": 0.1, "mat": "CFS"}]
+
+    # Values here correspond to signature curve basis and orthogonal based upon geometry
+    analysis_config: Analysis_Config = {'b_c': "S-S", 'n_eigs': 10}
+
+    # Set the section properties for this simple section
+    # Normally, these might be calculated by an external package
+    sect_props: Sect_Props = {
+        'cx': 1.67,
+        'cy': 4.5,
+        'x0': -2.27,
+        'y0': 4.5,
+        'phi': 0,
+        'A': 2.06,
+        'Ixx': 28.303,
+        'Ixy': 0,
+        'Iyy': 7.019,
+        'I11': 28.303,
+        'I22': 7.019,
+        'Cw': 0,
+        'J': 0,
+        'B1': 0,
+        'B2': 0,
+        'wn': np.array([])
+    }
+
+    # Perform the Finite Strip Method analysis
+    signature, curve, shapes, nodes_stressed, lengths = strip_new(
+        props=props,
+        nodes=nodes,
+        elements=elements,
+        forces={
+            'P': sect_props['A'] * 50,
+            'Mxx': 0,
+            'Myy': 0,
+            'M11': 0,
+            'M22': 0,
+            'restrain': False,
+            'offset': [-elements[0]["t"] / 2, -elements[0]["t"] / 2]
+        },
+        analysis_config=analysis_config,
+        sect_props=sect_props
+    )
+
+    # Return the important example results
+    # The signature curve is simply a matter of plotting the
+    # 'signature' values against the lengths
+    # (usually on a logarithmic axis)
+    return {
+        'X_values': lengths,
+        'Y_values': signature,
+        'Y_values_allmodes': curve,
+        'Orig_coords': nodes_stressed,
+        'Deformations': shapes
+    }

--- a/pycufsm/fsm.py
+++ b/pycufsm/fsm.py
@@ -9,7 +9,7 @@ from pycufsm.analysis import analysis
 from pycufsm.helpers import inputs_new_to_old, m_recommend
 from pycufsm.preprocess import stress_gen, yield_mp
 from pycufsm.types import (
-    B_C, Analysis_Config, ArrayLike, Cfsm_Config, Forces, GBT_Con, New_Constraint, New_Element,
+    BC, Analysis_Config, ArrayLike, Cfsm_Config, Forces, GBT_Con, New_Constraint, New_Element,
     New_Node_Props, New_Spring, Sect_Props, Yield_Force
 )
 
@@ -24,7 +24,7 @@ from pycufsm.types import (
 
 def strip(
     props: np.ndarray, nodes: np.ndarray, elements: np.ndarray, lengths: np.ndarray,
-    springs: np.ndarray, constraints: np.ndarray, gbt_con: GBT_Con, b_c: B_C, m_all: np.ndarray,
+    springs: np.ndarray, constraints: np.ndarray, gbt_con: GBT_Con, b_c: BC, m_all: np.ndarray,
     n_eigs: int, sect_props: Sect_Props
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Perform a finite strip analysis

--- a/pycufsm/fsm.py
+++ b/pycufsm/fsm.py
@@ -200,9 +200,10 @@ def strip(
                 # Transform k_s into global coordinates
                 node_i = spring[1]
                 node_j = spring[2]
-                if node_j == 0 or spring[7] == 0:  # spring is to ground
+                if node_j == -1 or spring[7] == 0:  # spring is to ground
                     # handle the spring to ground during assembly
                     alpha: float = 0  # use global coordinates for spring
+                    node_j = -1
                 else:  # spring is between nodes
                     x_i = nodes[node_i, 1]
                     y_i = nodes[node_i, 2]

--- a/pycufsm/helpers.py
+++ b/pycufsm/helpers.py
@@ -5,7 +5,7 @@ import numpy as np
 import pycufsm.cfsm
 import pycufsm.fsm
 from pycufsm.types import (
-    B_C, Analysis_Config, ArrayLike, Cfsm_Config, Cufsm_MAT_File, GBT_Con, New_Constraint,
+    BC, Analysis_Config, ArrayLike, Cfsm_Config, Cufsm_MAT_File, GBT_Con, New_Constraint,
     New_Element, New_Node_Props, New_Spring, PyCufsm_Input, Sect_Props
 )
 
@@ -126,7 +126,7 @@ def signature_ss(
     """
     i_springs = np.array([])
     i_constraints = np.array([])
-    i_b_c: B_C = 'S-S'
+    i_b_c: BC = 'S-S'
     i_m_all = np.ones((len(lengths), 1)).tolist()
 
     isignature, icurve, ishapes = pycufsm.fsm.strip(
@@ -455,7 +455,7 @@ def inputs_new_to_old(
     constraints: Optional[Sequence[New_Constraint]] = None,
     analysis_config: Optional[Analysis_Config] = None,
     cfsm_config: Optional[Cfsm_Config] = None
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, GBT_Con, B_C,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, GBT_Con, BC,
            np.ndarray, int]:
     """Converts new format of inputs to old (original CUFSM) format
 

--- a/pycufsm/helpers.py
+++ b/pycufsm/helpers.py
@@ -448,16 +448,15 @@ def load_mat(mat: Cufsm_MAT_File) -> PyCufsm_Input:
 def inputs_new_to_old(
     props: Dict[str, New_Props],
     nodes: np.ndarray,
-    lengths: Dict[int, List[int]],
+    lengths: Dict[float, List[int]],
     elements: List[New_Element],
     springs: Optional[List[New_Spring]] = None,
     constraints: Optional[List[New_Constraint]] = None,
     node_props: Optional[Dict[int, New_Node_Props]] = None,
     analysis_config: Optional[Analysis_Config] = None,
-    cfsm_config: Optional[Cfsm_Config] = None,
-    sect_props: Optional[Sect_Props] = None
+    cfsm_config: Optional[Cfsm_Config] = None
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, GBT_Con, B_C,
-           np.ndarray, int, Optional[Sect_Props]]:
+           np.ndarray, int]:
     """Converts new format of inputs to old (original CUFSM) format
 
     Args:
@@ -540,47 +539,46 @@ def inputs_new_to_old(
         sect_props (Sect_Props, optional): _description_. Defaults to None.
 
     Returns:
-        _type_: _description_
-        props: [mat_num stiff_x stiff_y nu_x nu_y bulk] 6 x n_mats
-        nodes: [node# x y dof_x dof_y dof_z dof_r stress] n_nodes x 8
-        elements: [elem# node_i node_j thick mat_num] n_elements x 5
-        lengths: [L1 L2 L3...] 1 x n_lengths lengths to be analysed
-        could be half-wavelengths for signature curve
-        or physical lengths for general b.c.
-        springs: [node# d.o.f. k_spring k_flag] where 1=x dir 2= y dir 3 = z dir 4 = q dir (twist)
-            flag says if k_stiff is a foundation stiffness or a total stiffness
-        constraints:: [node# e dof_e coeff node# k dof_k] e=dof to be eliminated
+        props (np.ndarray): [mat_num stiff_x stiff_y nu_x nu_y bulk] 6 x n_mats
+        nodes (np.ndarray): [node# x y dof_x dof_y dof_z dof_r stress] n_nodes x 8
+        elements (np.ndarray): [elem# node_i node_j thick mat_num] n_elements x 5
+        lengths (np.ndarray): [L1 L2 L3...] 1 x n_lengths lengths to be analyzed; 
+            could be half-wavelengths for signature curve or physical lengths for general b.c.
+        springs (np.ndarray): [node# d.o.f. k_spring k_flag] where 1=x dir 2= y dir 3 = z dir 
+            4 = q dir (twist) flag says if k_stiff is a foundation stiffness or a total stiffness
+        constraints (np.ndarray): [node# e dof_e coeff node# k dof_k] e=dof to be eliminated
             k=kept dof dof_e_node = coeff*dof_k_node_k
-        gbt_con: gbt_con.glob,gbt_con.dist, gbt_con.local, gbt_con.other vectors of 1's
-        and 0's referring to the inclusion (1) or exclusion of a given mode from the analysis,
-        gbt_con.o_space - choices of ST/O mode
-                1: ST basis
-                2: O space (null space of GDL) with respect to k_global
-                3: O space (null space of GDL) with respect to kg_global
-                4: O space (null space of GDL) in vector sense
-        gbt_con.norm - code for normalization (if normalization is done at all)
-                0: no normalization,
-                1: vector norm
-                2: strain energy norm
-                3: work norm
-        gbt_con.couple - coupled basis vs uncoupled basis for general
-                    B.C. especially for non-simply supported B.C.
-                1: uncoupled basis, the basis will be block diagonal
-                2: coupled basis, the basis is fully spanned
-        gbt_con.orth - natural basis vs modal basis
-                1: natural basis
-                2: modal basis, axial orthogonality
-                3: modal basis, load dependent orthogonality
-        b_c: ['S-S'] a string specifying boundary conditions to be analysed:
-        'S-S' simply-pimply supported boundary condition at loaded edges
-        'C-C' clamped-clamped boundary condition at loaded edges
-        'S-C' simply-clamped supported boundary condition at loaded edges
-        'C-F' clamped-free supported boundary condition at loaded edges
-        'C-G' clamped-guided supported boundary condition at loaded edges
-        m_all: m_all{length#}=[longitudinal_num# ... longitudinal_num#],
+        gbt_con (GBT_Con): gbt_con.glob,gbt_con.dist, gbt_con.local, gbt_con.other vectors of 1's
+            and 0's referring to the inclusion (1) or exclusion of a given mode from the analysis,
+            gbt_con.o_space - choices of ST/O mode
+                    1: ST basis
+                    2: O space (null space of GDL) with respect to k_global
+                    3: O space (null space of GDL) with respect to kg_global
+                    4: O space (null space of GDL) in vector sense
+            gbt_con.norm - code for normalization (if normalization is done at all)
+                    0: no normalization,
+                    1: vector norm
+                    2: strain energy norm
+                    3: work norm
+            gbt_con.couple - coupled basis vs uncoupled basis for general
+                        B.C. especially for non-simply supported B.C.
+                    1: uncoupled basis, the basis will be block diagonal
+                    2: coupled basis, the basis is fully spanned
+            gbt_con.orth - natural basis vs modal basis
+                    1: natural basis
+                    2: modal basis, axial orthogonality
+                    3: modal basis, load dependent orthogonality
+        b_c (str): ['S-S'] a string specifying boundary conditions to be analyzed:
+            'S-S' simply-pimply supported boundary condition at loaded edges
+            'C-C' clamped-clamped boundary condition at loaded edges
+            'S-C' simply-clamped supported boundary condition at loaded edges
+            'C-F' clamped-free supported boundary condition at loaded edges
+            'C-G' clamped-guided supported boundary condition at loaded edges
+        m_all (np.ndarray): m_all{length#}=[longitudinal_num# ... longitudinal_num#],
             longitudinal terms m for all the lengths in cell notation
-        each cell has a vector including the longitudinal terms for this length
-        n_eigs - the number of eigenvalues to be determined at length (default=10)
+            each cell has a vector including the longitudinal terms for this length
+        n_eigs (int): the number of eigenvalues to be determined at length (default=10)
+        sect_props (Sect_Props): _description_
     """
     # Convert props
     props_old: list = []
@@ -614,7 +612,7 @@ def inputs_new_to_old(
             elements_old.append([i, node1, node2, elem["t"], mat_index[elem["mat"]]])
 
     # Convert lengths and m_all
-    lengths_old: List[int] = []
+    lengths_old: List[float] = []
     m_all_old: List[List[int]] = []
     for length, m_a in lengths.items():
         lengths_old.append(length)
@@ -678,6 +676,5 @@ def inputs_new_to_old(
 
     return np.array(props_old), np.array(nodes_old), np.array(elements_old), np.array(
         lengths_old
-    ), np.array(springs_old), np.array(constraints_old), gbt_con_old, b_c_old, np.array(
-        m_all_old
-    ), n_eigs_old, sect_props
+    ), np.array(springs_old), np.array(constraints_old
+                                       ), gbt_con_old, b_c_old, np.array(m_all_old), n_eigs_old

--- a/pycufsm/helpers.py
+++ b/pycufsm/helpers.py
@@ -1,3 +1,4 @@
+from operator import itemgetter
 from typing import Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -6,7 +7,7 @@ import pycufsm.cfsm
 import pycufsm.fsm
 from pycufsm.types import (
     BC, Analysis_Config, ArrayLike, Cfsm_Config, Cufsm_MAT_File, GBT_Con, New_Constraint,
-    New_Element, New_Node_Props, New_Spring, PyCufsm_Input, Sect_Props
+    New_Element, New_Node_Props, New_Props, New_Spring, PyCufsm_Input, Sect_Props
 )
 
 # Originally developed for MATLAB by Benjamin Schafer PhD et al
@@ -463,9 +464,10 @@ def inputs_new_to_old(
         props (Dict[str, Dict[str, float]]): Dictionary of named materials and their properties
             {"mat_name": {E_x: float, E_y: float, nu_x: float, nu_y: float, bulk: float}}
         nodes (ArrayLike): 2D array of nodal coordinates
-            [[x, y]]
+            [[x, y]] or [[x, y, stress]]
             Note that any node numbers used in later inputs refer to the index of the node in
             this 'nodes' array, with the first node being node 0. 
+            If array only has 2 columns, then stress is assumed to be 0.0 initially.
         elements (Sequence[New_Element]): Element connectivity and properties 
             [{
                 nodes: "all"|List[int], # "all" or [node1, node2, node3, ...] in sequence
@@ -485,7 +487,6 @@ def inputs_new_to_old(
                     dof_y: bool,    # defaults to True (included / not constrained)
                     dof_z: bool,    # defaults to True (included / not constrained)
                     dof_q: bool,    # defaults to True (included / not constrained)
-                    stress: float   # defaults to 0.0 (no stress)
                 }
             }
             Defaults to None, and taken as all DOFs included and all 0.0 stresses if so
@@ -616,26 +617,28 @@ def inputs_new_to_old(
 
     # Convert nodes
     nodes_old: list = []
+    nodes = np.array(nodes)
     if node_props is None:
         node_props = {}
+    # Add a column of zeros, for zero stress, if no stress was set
+    if np.shape(nodes)[1] == 2:
+        nodes = np.c_[nodes, np.zeros(len(nodes))]
     if "all" in node_props:
         dof_x = int(node_props["all"]["dof_x"]) if "dof_x" in node_props["all"] else 1
         dof_y = int(node_props["all"]["dof_y"]) if "dof_y" in node_props["all"] else 1
         dof_z = int(node_props["all"]["dof_z"]) if "dof_z" in node_props["all"] else 1
         dof_q = int(node_props["all"]["dof_q"]) if "dof_q" in node_props["all"] else 1
-        stress = node_props["all"]["stress"] if "stress" in node_props["all"] else 0.0
     for i, node in enumerate(nodes):
         if "all" in node_props:
-            nodes_old.append([i, node[0], node[1], dof_x, dof_y, dof_z, dof_q, stress])
+            nodes_old.append([i, node[0], node[1], dof_x, dof_y, dof_z, dof_q, node[2]])
         elif i in node_props:
             dof_x = int(node_props[i]["dof_x"]) if "dof_x" in node_props[i] else 1
             dof_y = int(node_props[i]["dof_y"]) if "dof_y" in node_props[i] else 1
             dof_z = int(node_props[i]["dof_z"]) if "dof_z" in node_props[i] else 1
             dof_q = int(node_props[i]["dof_q"]) if "dof_q" in node_props[i] else 1
-            stress = node_props[i]["stress"] if "stress" in node_props[i] else 0.0
-            nodes_old.append([i, node[0], node[1], dof_x, dof_y, dof_z, dof_q, stress])
+            nodes_old.append([i, node[0], node[1], dof_x, dof_y, dof_z, dof_q, node[2]])
         else:
-            nodes_old.append([i, node[0], node[1], 1, 1, 1, 1, 0.0])
+            nodes_old.append([i, node[0], node[1], 1, 1, 1, 1, node[2]])
 
     # Convert elements
     elements_old: list = []
@@ -718,3 +721,287 @@ def inputs_new_to_old(
         lengths_old
     ), np.array(springs_old), np.array(constraints_old
                                        ), gbt_con_old, b_c_old, np.array(m_all_old), n_eigs_old
+
+
+def inputs_old_to_new(
+    props: ArrayLike,
+    nodes: ArrayLike,
+    elements: ArrayLike,
+    lengths: ArrayLike,
+    springs: ArrayLike,
+    constraints: ArrayLike,
+    gbt_con: GBT_Con,
+    b_c: BC,
+    m_all: ArrayLike,
+    n_eigs: int,
+) -> Tuple[Dict[str, New_Props], np.ndarray, List[New_Element], Dict[float, np.ndarray], Dict[Union[
+        Literal["all"], int], New_Node_Props], List[New_Spring], List[New_Constraint],
+           Analysis_Config, Cfsm_Config]:
+    """Converts old (original CUFSM) format of inputs to new format
+
+    Args:
+        props (np.ndarray): [mat_num stiff_x stiff_y nu_x nu_y bulk] 6 x n_mats
+        nodes (np.ndarray): [node# x y dof_x dof_y dof_z dof_r stress] n_nodes x 8
+        elements (np.ndarray): [elem# node_i node_j thick mat_num] n_elements x 5
+        lengths (np.ndarray): [L1 L2 L3...] 1 x n_lengths lengths to be analyzed; 
+            could be half-wavelengths for signature curve or physical lengths for general b.c.
+        springs (np.ndarray): [node# d.o.f. k_spring k_flag] where 1=x dir 2= y dir 3 = z dir 
+            4 = q dir (twist) flag says if k_stiff is a foundation stiffness or a total stiffness
+        constraints (np.ndarray): [node# e dof_e coeff node# k dof_k] e=dof to be eliminated
+            k=kept dof dof_e_node = coeff*dof_k_node_k
+        gbt_con (GBT_Con): gbt_con.glob,gbt_con.dist, gbt_con.local, gbt_con.other vectors of 1's
+            and 0's referring to the inclusion (1) or exclusion of a given mode from the analysis,
+            gbt_con.o_space - choices of ST/O mode
+                    1: ST basis
+                    2: O space (null space of GDL) with respect to k_global
+                    3: O space (null space of GDL) with respect to kg_global
+                    4: O space (null space of GDL) in vector sense
+            gbt_con.norm - code for normalization (if normalization is done at all)
+                    0: no normalization,
+                    1: vector norm
+                    2: strain energy norm
+                    3: work norm
+            gbt_con.couple - coupled basis vs uncoupled basis for general
+                        B.C. especially for non-simply supported B.C.
+                    1: uncoupled basis, the basis will be block diagonal
+                    2: coupled basis, the basis is fully spanned
+            gbt_con.orth - natural basis vs modal basis
+                    1: natural basis
+                    2: modal basis, axial orthogonality
+                    3: modal basis, load dependent orthogonality
+        b_c (str): ['S-S'] a string specifying boundary conditions to be analyzed:
+            'S-S' simply-pimply supported boundary condition at loaded edges
+            'C-C' clamped-clamped boundary condition at loaded edges
+            'S-C' simply-clamped supported boundary condition at loaded edges
+            'C-F' clamped-free supported boundary condition at loaded edges
+            'C-G' clamped-guided supported boundary condition at loaded edges
+        m_all (np.ndarray): m_all{length#}=[longitudinal_num# ... longitudinal_num#],
+            longitudinal terms m for all the lengths in cell notation
+            each cell has a vector including the longitudinal terms for this length
+        n_eigs (int): the number of eigenvalues to be determined at length (default=10)
+        sect_props (Sect_Props): _description_
+
+    Returns:
+        props (Dict[str, Dict[str, float]]): Dictionary of named materials and their properties
+            {"mat_name": {E_x: float, E_y: float, nu_x: float, nu_y: float, bulk: float}}
+        nodes (ArrayLike): 2D array of nodal coordinates
+            [[x, y]]
+            Note that any node numbers used in later inputs refer to the index of the node in
+            this 'nodes' array, with the first node being node 0. 
+        elements (Sequence[New_Element]): Element connectivity and properties 
+            [{
+                nodes: "all"|List[int], # "all" or [node1, node2, node3, ...] in sequence
+                t: float,               # thickness
+                mat: str                # "mat_name"
+            )].
+            nodes: "all" is a special indicator that all nodes should be connected sequentially
+            If nodes is given as an array, any number of nodal indices may be listed in order
+        lengths (Union[ArrayLike, set, Dict[float, ArrayLike]): Half-wavelengths for analysis
+            [length1, length2, ...]     # lengths only (assumes [m_a] = [1] for each length) 
+            {length: list[int]}         # length: [m_a]
+        node_props (Optional[Dict[Union[Literal["all", int], New_Node_Props]]): DOF restrictions 
+            and stresses on nodes.
+            {
+                node_#|"all": {
+                    dof_x: bool,    # defaults to True (included / not constrained)
+                    dof_y: bool,    # defaults to True (included / not constrained)
+                    dof_z: bool,    # defaults to True (included / not constrained)
+                    dof_q: bool,    # defaults to True (included / not constrained)
+                    stress: float   # defaults to 0.0 (no stress)
+                }
+            }
+            Defaults to None, and taken as all DOFs included and all 0.0 stresses if so
+        springs (Optional[Sequence[New_Spring]]): Definition of any springs in cross-section
+            [{
+                node: int,      # node # 
+                k_x: float,     # x stiffness
+                k_y: float,     # y stiffness
+                k_z: float,     # z stiffness
+                k_q: float,     # q stiffness
+                k_type: str,    # "foundation"|"node_pair"|"total" - stiffness type
+                node_pair: int, # node # to which to pair (if relevant)
+                discrete: bool, # whether spring is at a discrete location
+                y: float,       # location of discrete spring
+            }]
+            Defaults to None.
+        constraints (Optional[Sequence[New_Constraint]]): Definition of any constraints in section
+            [{
+                elim_node: int,     # node #
+                elim_dof: str,      # "x"|"y"|"z"|"q" - "q" is the twist dof 
+                coeff: float,       # elim_dof = coeff * keep_dof
+                keep_node: int,     # node #
+                keep_dof: str       # "x"|"y"|"z"|"q" - "q" is the twist dof
+            }]
+            Defaults to None.
+        analysis_config (Optional[Analysis_Config]): Configuration options for any analysis
+            {
+                b_c: str,           # "S-S"|"C-C"|"S-C"|"C-F"|"C-G" - boundary condition type
+                n_eigs: int         # number of eigenvalues to consider
+            }
+            Defaults to None, and taken as {b_c: "S-S", n_eigs: 10} if so.
+            Boundary condition types (at loaded edges):
+                'S-S' simple-simple
+                'C-C' clamped-clamped
+                'S-C' simple-clamped
+                'C-F' clamped-free
+                'C-G' clamped-guided
+        cfsm_config (Optional[Cfsm_Config]): Configuration options for cFSM (constrained modes) 
+            {
+                glob_modes: list(int),      # list of 1's (inclusion) and 0's (exclusion) for 
+                    each mode from the analysis
+                dist_modes: list(int),      # list of 1's (inclusion) and 0's (exclusion) for 
+                    each mode from the analysis
+                local_modes: list(int),     # list of 1's (inclusion) and 0's (exclusion) for 
+                    each mode from the analysis
+                other_modes: list(int),     # list of 1's (inclusion) and 0's (exclusion) for 
+                    each mode from the analysis
+                null_space: str,            # "ST"|"k_global"|"kg_global"|"vector"
+                normalization: str,         # "none"|"vector"|"strain_energy"|"work"
+                coupled: bool,              # coupled basis vs uncoupled basis for general B.C.
+                orthogonality: str          # "natural"|"modal_axial"|"modal_load" - natural or 
+                    modal basis
+            }
+            Defaults to None, in which case no cFSM analysis is performed
+            null_space:
+                "ST": ST basis
+                "k_global": null space of GDL with respect to k_global
+                "kg_global": null space of GDL with respect to kg_global
+                "vector": null space of GDL in vector sense
+            coupled:        basis for general B.C. especially for non-simply supported B.C.s
+                uncoupled basis = the basis will be block diagonal
+                coupled basis = the basis is fully spanned
+            orthogonality:      natural basis vs modal basis
+                "natural": natural basis
+                "modal_axial": modal basis, axial orthogonality
+                "modal_load": modal basis, load dependent orthogonality
+    """
+    # Convert props
+    props_new: Dict[str, New_Props] = {}
+    for mat in props:
+        props_new[f"mat #{mat[0]}"] = {
+            "E_x": mat[1],
+            "E_y": mat[2],
+            "nu_x": mat[3],
+            "nu_y": mat[4],
+            "bulk": mat[5]
+        }
+
+    # Convert nodes
+    nodes = np.array(sorted(nodes, key=itemgetter(0)))  # sort by node #
+    nodes_new: np.ndarray = np.c_[nodes[:, 1:2], nodes[:, 7]]
+    node_props_new: Dict[Union[Literal["all"], int], New_Node_Props] = {}
+    node_index: Dict[int, int] = {}
+    for i, node in enumerate(nodes):
+        node_index[node[0]] = i
+        if any(node[3:6] == 0):
+            node_props_new[i] = {
+                "dof_x": node[3],
+                "dof_y": node[4],
+                "dof_z": node[5],
+                "dof_q": node[6],
+            }
+
+    # Convert elements
+    elements = np.array(sorted(elements, key=itemgetter(0)))  # sort by elem #
+    elements_new: List[New_Element] = [{
+        "nodes": [node_index[elements[0, 1]], node_index[elements[0, 2]]],
+        "t": elements[0, 3],
+        "mat": f"mat #{elements[0,4]}",
+    }]
+    i = 1
+    while i < len(elements):
+        while elements[i - 1, 2] == elements[i, 1] and i < len(elements):
+            elements_new[-1]["nodes"].append(elements[i, 2])  # type: ignore
+            i += 1
+        if i != len(elements) - 1:
+            elements_new.append({
+                "nodes": [node_index[elements[i, 1]], node_index[elements[i, 2]]],
+                "t": elements[i, 3],
+                "mat": f"mat #{elements[i,4]}",
+            })
+        i += 1
+    if len(elements_new) == 1:
+        elements_new[0]["nodes"] = "all"
+
+    # Convert lengths and m_all
+    lengths_new: Dict[float, np.ndarray] = {}
+    for i, length in enumerate(lengths):
+        lengths_new[length] = np.array(m_all[i])
+
+    # Convert springs
+    springs_new: List[New_Spring] = []
+    k_type: Literal["foundation", "total", "node_pair"]
+    for spring in springs:
+        if spring[1] != -1:
+            k_type = "node_pair"
+        elif spring[6] == 1:
+            k_type = "total"
+        elif spring[6] == 0:
+            k_type = "foundation"
+        else:
+            raise ValueError(
+                "Unknown spring type; either a node pair must be set, or "
+                + "spring must be set as a foundation spring"
+            )
+        springs_new.append({
+            "node": node_index[spring[0]],
+            "node_pair": node_index[spring[1]],
+            "k_x": spring[2],
+            "k_y": spring[3],
+            "k_z": spring[4],
+            "k_q": spring[5],
+            "k_type": k_type,
+            "discrete": bool(spring[7]),
+            "y": spring[8],
+        })
+
+    # Convert constraints
+    dof_conv: Dict[int, Literal["x", "y", "z", "q"]] = {1: "x", 2: "y", 3: "z", 4: "q"}
+    constraints_new: List[New_Constraint] = []
+    for constraint in constraints:
+        constraints_new.append({
+            "elim_node": node_index[constraint[0]],
+            "elim_dof": dof_conv[constraint[1]],
+            "coeff": constraint[2],
+            "keep_node": node_index[constraint[3]],
+            "keep_dof": dof_conv[constraint[4]],
+        })
+
+    # Convert configurations
+    analysis_config: Analysis_Config = {
+        "b_c": b_c,
+        "n_eigs": n_eigs,
+    }
+
+    o_space_conv: Dict[int, Literal["ST", "k_global", "kg_global", "vector"]] = {
+        1: "ST",
+        2: "k_global",
+        3: "kg_global",
+        4: "vector"
+    }
+    norm_conv: Dict[int, Literal["none", "vector", "strain_energy", "work"]] = {
+        0: "none",
+        1: "vector",
+        2: "strain_energy",
+        3: "work"
+    }
+    orth_conv: Dict[int, Literal["natural", "modal_axial", "modal_load"]] = {
+        1: "natural",
+        2: "modal_axial",
+        3: "modal_load"
+    }
+    cfsm_config: Cfsm_Config = {
+        "glob_modes": gbt_con["glob"],
+        "dist_modes": gbt_con["dist"],
+        "local_modes": gbt_con["local"],
+        "other_modes": gbt_con["other"],
+        "null_space": o_space_conv[gbt_con["o_space"]],
+        "normalization": norm_conv[gbt_con["norm"]],
+        "coupled": True if gbt_con["couple"] == 2 else False,
+        "orthogonality": orth_conv[gbt_con["orth"]],
+    }
+
+    return (
+        props_new, nodes_new, elements_new, lengths_new, node_props_new, springs_new,
+        constraints_new, analysis_config, cfsm_config
+    )

--- a/pycufsm/preprocess.py
+++ b/pycufsm/preprocess.py
@@ -441,9 +441,21 @@ def yield_mp(
     BWS, Aug 2000
     BWS, May 2019 trap nan when flat plate or other properites are zero
     """
-    f_yield: Forces = {'P': 0, 'Mxx': 0, 'Myy': 0, 'M11': 0, 'M22': 0}
+    f_yield: Forces = {
+        'P': 0,
+        'Mxx': 0,
+        'Myy': 0,
+        'M11': 0,
+        'M22': 0,
+        'restrain': restrained,
+        'offset': [0, 0]
+    }
 
     f_yield['P'] = f_y * sect_props['A']
+
+    # TODO: This seems like a weirdly over-complicated way to calculate yield stresses...
+    # especially given that if restrained == False, then Mxx just simply equals M11, yes?
+
     #account for the possibility of restrained bending vs. unrestrained bending
     if restrained is False:
         sect_props['Ixy'] = 0
@@ -527,6 +539,10 @@ def stress_gen(
     BWS, 1998
     B Smith, Aug 2020
     """
+    if 'restrain' in forces:
+        restrained = forces['restrain']
+    if 'offset' in forces:
+        offset_basis = list(forces['offset'])
     if isinstance(offset_basis, float) or isinstance(offset_basis, int):
         offset_basis = [offset_basis, offset_basis]
 

--- a/pycufsm/preprocess.py
+++ b/pycufsm/preprocess.py
@@ -453,9 +453,6 @@ def yield_mp(
 
     f_yield['P'] = f_y * sect_props['A']
 
-    # TODO: This seems like a weirdly over-complicated way to calculate yield stresses...
-    # especially given that if restrained == False, then Mxx just simply equals M11, yes?
-
     #account for the possibility of restrained bending vs. unrestrained bending
     if restrained is False:
         sect_props['Ixy'] = 0

--- a/pycufsm/types.py
+++ b/pycufsm/types.py
@@ -1,14 +1,16 @@
-from typing import Any, List
+from typing import Any, List, Literal, Union
 
 import numpy as np
 from typing_extensions import TypedDict
 
+B_C = Literal["S-S", "C-C", "S-C", "C-F", "C-G"]  # pylint: disable=invalid-name
+
 GBT_Con = TypedDict(
     'GBT_Con', {
-        'glob': List[int],
-        'dist': List[int],
-        'local': List[int],
-        'other': List[int],
+        'glob': List[Literal[0, 1]],
+        'dist': List[Literal[0, 1]],
+        'local': List[Literal[0, 1]],
+        'other': List[Literal[0, 1]],
         'o_space': int,
         'couple': int,
         'orth': int,
@@ -95,5 +97,84 @@ PyCufsm_Input = TypedDict(
         'shapes': np.ndarray,
         'clas': str,
         'GBTcon': GBT_Con
+    }
+)
+
+New_Props = TypedDict(
+    'New_Props', {
+        'E_x': float,
+        'E_y': float,
+        'nu_x': float,
+        'nu_y': float,
+        'bulk': float
+    }
+)
+
+New_Element = TypedDict(
+    'New_Element',
+    {
+        'nodes': Union[str, List[int]],  # "all" or [node1, node2, node3, ...]
+        't': float,  # thickness
+        'mat': str  # "mat_name"
+    }
+)
+
+New_Spring = TypedDict(
+    'New_Spring',
+    {
+        'node': int,  # node # 
+        'k_x': float,  # x stiffness
+        'k_y': float,  # y stiffness
+        'k_z': float,  # z stiffness
+        'k_q': float,  # q stiffness
+        'k_type': Literal["foundation", "total",
+                          "node_pair"],  # "foundation"|"total"|"node_pair" - stiffness type,
+        'node_pair': int,  # node number to which to pair (if relevant)
+        'discrete': bool,
+        'y': float,  # location of discrete spring
+    }
+)
+
+New_Constraint = TypedDict(
+    'New_Constraint',
+    {
+        'elim_node': int,  # node #
+        'elim_dof': Literal["x", "y", "z", "q"],  # "q" is the twist dof 
+        'coeff': float,  # elim_dof = coeff * keep_dof
+        'keep_node': int,  # node #
+        'keep_dof': Literal["x", "y", "z", "q"],  # "q" is the twist dof
+    }
+)
+
+New_Node_Props = TypedDict(
+    'New_Node_Props',
+    {
+        'dof_x': bool,  # defaults to True
+        'dof_y': bool,  # defaults to True
+        'dof_z': bool,  # defaults to True
+        'dof_q': bool,  # defaults to True
+        'stress': float,  # defaults to 0.0
+    }
+)
+
+Analysis_Config = TypedDict(
+    'Analysis_Config',
+    {
+        'b_c': B_C,  # boundary condition type
+        'n_eigs': int,  # number of eigenvalues to consider
+    }
+)
+
+Cfsm_Config = TypedDict(
+    'Cfsm_Config',
+    {
+        'glob_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'dist_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'local_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'other_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'null_space': Literal["ST", "k_global", "kg_global", "vector"],
+        'normalization': Literal["none", "vector", "strain_energy", "work"],
+        'coupled': bool,  # coupled basis vs uncoupled basis for general B.C.
+        'orthogonality': Literal["natural", "modal_axial", "modal_load"],  # natural or modal basis
     }
 )

--- a/pycufsm/types.py
+++ b/pycufsm/types.py
@@ -109,7 +109,6 @@ New_Node_Props = TypedDict(
         'dof_y': bool,  # defaults to True
         'dof_z': bool,  # defaults to True
         'dof_q': bool,  # defaults to True
-        'stress': float,  # defaults to 0.0
     }
 )
 

--- a/pycufsm/types.py
+++ b/pycufsm/types.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing_extensions import TypedDict
 
 __all__ = [
-    'ArrayLike', 'B_C', 'Directions', 'ForceTypes', 'Analysis_Config', 'Cfsm_Config',
+    'ArrayLike', 'BC', 'Directions', 'ForceTypes', 'Analysis_Config', 'Cfsm_Config',
     'Cufsm_MAT_File', 'Forces', 'GBT_Con', 'New_Constraint', 'New_Element', 'New_Node_Props',
     'New_Props', 'New_Props_min', 'New_Spring', 'PyCufsm_Input', 'Sect_Geom', 'Sect_Props',
     'Yield_Force'
@@ -12,7 +12,7 @@ __all__ = [
 
 ArrayLike = Union[np.ndarray, list, tuple]
 
-B_C = Literal["S-S", "C-C", "S-C", "C-F", "C-G"]  # pylint: disable=invalid-name
+BC = Literal["S-S", "C-C", "S-C", "C-F", "C-G"]
 
 Directions = Literal["Pos", "Neg", "+", "-"]
 
@@ -21,7 +21,7 @@ ForceTypes = Literal["Mxx", "Myy", "M11", "M22", "P"]
 Analysis_Config = TypedDict(
     'Analysis_Config',
     {
-        'b_c': B_C,  # boundary condition type
+        'b_c': BC,  # boundary condition type
         'n_eigs': int,  # number of eigenvalues to consider
     }
 )

--- a/pycufsm/types.py
+++ b/pycufsm/types.py
@@ -3,7 +3,66 @@ from typing import Any, List, Literal, Union
 import numpy as np
 from typing_extensions import TypedDict
 
+__all__ = [
+    'ArrayLike', 'B_C', 'Analysis_Config', 'Cfsm_Config', 'Cufsm_MAT_File', 'Forces', 'GBT_Con',
+    'New_Constraint', 'New_Element', 'New_Node_Props', 'New_Props', 'New_Props_min', 'New_Spring',
+    'PyCufsm_Input', 'Sect_Geom', 'Sect_Props'
+]
+
+ArrayLike = Union[np.ndarray, list, tuple]
+
 B_C = Literal["S-S", "C-C", "S-C", "C-F", "C-G"]  # pylint: disable=invalid-name
+
+Analysis_Config = TypedDict(
+    'Analysis_Config',
+    {
+        'b_c': B_C,  # boundary condition type
+        'n_eigs': int,  # number of eigenvalues to consider
+    }
+)
+
+Cfsm_Config = TypedDict(
+    'Cfsm_Config',
+    {
+        'glob_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'dist_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'local_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'other_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
+        'null_space': Literal["ST", "k_global", "kg_global", "vector"],
+        'normalization': Literal["none", "vector", "strain_energy", "work"],
+        'coupled': bool,  # coupled basis vs uncoupled basis for general B.C.
+        'orthogonality': Literal["natural", "modal_axial", "modal_load"],  # natural or modal basis
+    }
+)
+
+Cufsm_MAT_File = TypedDict(
+    'Cufsm_MAT_File',
+    {
+        'node': list,
+        'elem': list,
+        'lengths': list,
+        'prop': list,
+        'constraints': list,
+        'springs': list,
+        'curve': list,
+        'GBTcon':
+            Any,  # this is some special structure with string dictionaries but a dtype attribute
+        'shapes': list,
+        'clas': str,
+    }
+)
+
+Forces = TypedDict(
+    'Forces', {
+        'P': float,
+        'Mxx': float,
+        'Myy': float,
+        'M11': float,
+        'M22': float,
+        'restrain': bool,
+        'offset': ArrayLike
+    }
+)
 
 GBT_Con = TypedDict(
     'GBT_Con', {
@@ -18,34 +77,77 @@ GBT_Con = TypedDict(
     }
 )
 
-Forces = TypedDict(
-    'Forces', {
-        'P': float,
-        'Mxx': float,
-        'Myy': float,
-        'M11': float,
-        'M22': float,
+New_Constraint = TypedDict(
+    'New_Constraint',
+    {
+        'elim_node': int,  # node #
+        'elim_dof': Literal["x", "y", "z", "q"],  # "q" is the twist dof 
+        'coeff': float,  # elim_dof = coeff * keep_dof
+        'keep_node': int,  # node #
+        'keep_dof': Literal["x", "y", "z", "q"],  # "q" is the twist dof
     }
 )
 
-Sect_Props = TypedDict(
-    'Sect_Props', {
-        "A": float,
-        "cx": float,
-        "cy": float,
-        "Ixx": float,
-        "Iyy": float,
-        "Ixy": float,
-        "phi": float,
-        "I11": float,
-        "I22": float,
-        "J": float,
-        "x0": float,
-        "y0": float,
-        "Cw": float,
-        "B1": float,
-        "B2": float,
-        "wn": np.ndarray
+New_Element = TypedDict(
+    'New_Element',
+    {
+        'nodes': Union[str, List[int]],  # "all" or [node1, node2, node3, ...]
+        't': float,  # thickness
+        'mat': str  # "mat_name"
+    }
+)
+
+New_Node_Props = TypedDict(
+    'New_Node_Props',
+    {
+        'dof_x': bool,  # defaults to True
+        'dof_y': bool,  # defaults to True
+        'dof_z': bool,  # defaults to True
+        'dof_q': bool,  # defaults to True
+        'stress': float,  # defaults to 0.0
+    }
+)
+
+New_Props = TypedDict(
+    'New_Props', {
+        'E_x': float,
+        'E_y': float,
+        'nu_x': float,
+        'nu_y': float,
+        'bulk': float
+    }
+)
+
+New_Props_min = TypedDict('New_Props_min', {'E': float, 'nu': float})
+
+New_Spring = TypedDict(
+    'New_Spring',
+    {
+        'node': int,  # node # 
+        'k_x': float,  # x stiffness
+        'k_y': float,  # y stiffness
+        'k_z': float,  # z stiffness
+        'k_q': float,  # q stiffness
+        'k_type': Literal["foundation", "total",
+                          "node_pair"],  # "foundation"|"total"|"node_pair" - stiffness type,
+        'node_pair': int,  # node number to which to pair (if relevant)
+        'discrete': bool,
+        'y': float,  # location of discrete spring
+    }
+)
+
+PyCufsm_Input = TypedDict(
+    'PyCufsm_Input', {
+        'nodes': np.ndarray,
+        'elements': np.ndarray,
+        'lengths': np.ndarray,
+        'props': np.ndarray,
+        'constraints': np.ndarray,
+        'springs': np.ndarray,
+        'curve': np.ndarray,
+        'shapes': np.ndarray,
+        'clas': str,
+        'GBTcon': GBT_Con
     }
 )
 
@@ -68,113 +170,23 @@ Sect_Geom = TypedDict(
     }
 )
 
-Cufsm_MAT_File = TypedDict(
-    'Cufsm_MAT_File',
-    {
-        'node': list,
-        'elem': list,
-        'lengths': list,
-        'prop': list,
-        'constraints': list,
-        'springs': list,
-        'curve': list,
-        'GBTcon':
-            Any,  # this is some special structure with string dictionaries but a dtype attribute
-        'shapes': list,
-        'clas': str,
-    }
-)
-
-PyCufsm_Input = TypedDict(
-    'PyCufsm_Input', {
-        'nodes': np.ndarray,
-        'elements': np.ndarray,
-        'lengths': np.ndarray,
-        'props': np.ndarray,
-        'constraints': np.ndarray,
-        'springs': np.ndarray,
-        'curve': np.ndarray,
-        'shapes': np.ndarray,
-        'clas': str,
-        'GBTcon': GBT_Con
-    }
-)
-
-New_Props = TypedDict(
-    'New_Props', {
-        'E_x': float,
-        'E_y': float,
-        'nu_x': float,
-        'nu_y': float,
-        'bulk': float
-    }
-)
-
-New_Element = TypedDict(
-    'New_Element',
-    {
-        'nodes': Union[str, List[int]],  # "all" or [node1, node2, node3, ...]
-        't': float,  # thickness
-        'mat': str  # "mat_name"
-    }
-)
-
-New_Spring = TypedDict(
-    'New_Spring',
-    {
-        'node': int,  # node # 
-        'k_x': float,  # x stiffness
-        'k_y': float,  # y stiffness
-        'k_z': float,  # z stiffness
-        'k_q': float,  # q stiffness
-        'k_type': Literal["foundation", "total",
-                          "node_pair"],  # "foundation"|"total"|"node_pair" - stiffness type,
-        'node_pair': int,  # node number to which to pair (if relevant)
-        'discrete': bool,
-        'y': float,  # location of discrete spring
-    }
-)
-
-New_Constraint = TypedDict(
-    'New_Constraint',
-    {
-        'elim_node': int,  # node #
-        'elim_dof': Literal["x", "y", "z", "q"],  # "q" is the twist dof 
-        'coeff': float,  # elim_dof = coeff * keep_dof
-        'keep_node': int,  # node #
-        'keep_dof': Literal["x", "y", "z", "q"],  # "q" is the twist dof
-    }
-)
-
-New_Node_Props = TypedDict(
-    'New_Node_Props',
-    {
-        'dof_x': bool,  # defaults to True
-        'dof_y': bool,  # defaults to True
-        'dof_z': bool,  # defaults to True
-        'dof_q': bool,  # defaults to True
-        'stress': float,  # defaults to 0.0
-    }
-)
-
-Analysis_Config = TypedDict(
-    'Analysis_Config',
-    {
-        'b_c': B_C,  # boundary condition type
-        'n_eigs': int,  # number of eigenvalues to consider
-    }
-)
-
-Cfsm_Config = TypedDict(
-    'Cfsm_Config',
-    {
-        'glob_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
-        'dist_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
-        'local_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
-        'other_modes': List[Literal[0, 1]],  # list of 1's (inclusion) and 0's (exclusion)
-        'null_space': Literal["ST", "k_global", "kg_global", "vector"],
-        'normalization': Literal["none", "vector", "strain_energy", "work"],
-        'coupled': bool,  # coupled basis vs uncoupled basis for general B.C.
-        'orthogonality': Literal["natural", "modal_axial", "modal_load"],  # natural or modal basis
+Sect_Props = TypedDict(
+    'Sect_Props', {
+        "A": float,
+        "cx": float,
+        "cy": float,
+        "Ixx": float,
+        "Iyy": float,
+        "Ixy": float,
+        "phi": float,
+        "I11": float,
+        "I22": float,
+        "J": float,
+        "x0": float,
+        "y0": float,
+        "Cw": float,
+        "B1": float,
+        "B2": float,
+        "wn": np.ndarray
     }
 )

--- a/pycufsm/types.py
+++ b/pycufsm/types.py
@@ -4,14 +4,19 @@ import numpy as np
 from typing_extensions import TypedDict
 
 __all__ = [
-    'ArrayLike', 'B_C', 'Analysis_Config', 'Cfsm_Config', 'Cufsm_MAT_File', 'Forces', 'GBT_Con',
-    'New_Constraint', 'New_Element', 'New_Node_Props', 'New_Props', 'New_Props_min', 'New_Spring',
-    'PyCufsm_Input', 'Sect_Geom', 'Sect_Props'
+    'ArrayLike', 'B_C', 'Directions', 'ForceTypes', 'Analysis_Config', 'Cfsm_Config',
+    'Cufsm_MAT_File', 'Forces', 'GBT_Con', 'New_Constraint', 'New_Element', 'New_Node_Props',
+    'New_Props', 'New_Props_min', 'New_Spring', 'PyCufsm_Input', 'Sect_Geom', 'Sect_Props',
+    'Yield_Force'
 ]
 
 ArrayLike = Union[np.ndarray, list, tuple]
 
 B_C = Literal["S-S", "C-C", "S-C", "C-F", "C-G"]  # pylint: disable=invalid-name
+
+Directions = Literal["Pos", "Neg", "+", "-"]
+
+ForceTypes = Literal["Mxx", "Myy", "M11", "M22", "P"]
 
 Analysis_Config = TypedDict(
     'Analysis_Config',
@@ -91,7 +96,7 @@ New_Constraint = TypedDict(
 New_Element = TypedDict(
     'New_Element',
     {
-        'nodes': Union[str, List[int]],  # "all" or [node1, node2, node3, ...]
+        'nodes': Union[Literal["all"], List[int]],  # "all" or [node1, node2, node3, ...]
         't': float,  # thickness
         'mat': str  # "mat_name"
     }
@@ -118,7 +123,7 @@ New_Props = TypedDict(
     }
 )
 
-New_Props_min = TypedDict('New_Props_min', {'E': float, 'nu': float})
+New_Props_min = TypedDict('New_Props_min', {'E': float, 'nu': float, 'f_y': float})
 
 New_Spring = TypedDict(
     'New_Spring',
@@ -188,5 +193,15 @@ Sect_Props = TypedDict(
         "B1": float,
         "B2": float,
         "wn": np.ndarray
+    }
+)
+
+Yield_Force = TypedDict(
+    'Yield_Force', {
+        "force": ForceTypes,
+        "direction": Directions,
+        "f_y": float,
+        "restrain": bool,
+        "offset": ArrayLike
     }
 )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,7 +3,8 @@ import scipy.io
 from pytest import approx, raises
 
 import pycufsm.examples.example_1 as example_1
-from pycufsm import cutwp, fsm, helpers, preprocess
+import pycufsm.examples.example_1_new as example_1_new
+from pycufsm import cutwp, fsm, helpers
 
 from .fixtures.e2e_fixtures import *
 from .utils import pspec_context
@@ -48,23 +49,19 @@ def describe_end_to_end_tests():
 
     def context_example_1():
 
-        @pspec_context("Example 1")
+        @pspec_context("Example 1: Both old and new input formats")
         def describe():
             pass
 
-        results = example_1.__main__()
+        results_old = example_1.__main__()
+        results_new = example_1_new.__main__()
 
-        def it_results_in_correct_solution():
-            assert np.allclose(
-                results["X_values"],
-                np.array([
-                    0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4, 4.25,
-                    4.5, 4.75, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24,
-                    26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 66, 72,
-                    78, 84, 90, 96, 102, 108, 114, 120, 132, 144, 156, 168, 180, 204, 228, 252, 276,
-                    300
-                ])
-            )
+        def it_results_in_matching_stresses():
+            assert np.allclose(results_old["Orig_coords"], results_new["Orig_coords"])
+
+        def it_results_in_matching_solutions():
+            assert np.allclose(results_old["Y_values"], results_new["Y_values"])
+            assert np.allclose(results_old["Y_values_allmodes"], results_new["Y_values_allmodes"])
 
     def context_dsm_3_2_1_c_with_lips_Mx():
 


### PR DESCRIPTION
Add new main user input format which:
- Defaults to configuration that assumes a basic signature curve analysis, as is most common
- Greatly reduces the quantity of repetitive numbers that need to be input, including:
    - nodes: instead of having to manually enable every DOF on every single node, ask separately if any DOFs should be _disabled_
    - elements: instead of manually defining every element, _default_ to assuming that nodes have been entered sequentially and should be linked by elements sequentially and have a constant thickness and material - as in most any real-world open section)
    - stresses: instead of manually having to enter them or to manually run stress_gen(), just add an optional parameter 'forces' in which forces can be passed in directly