### PR TITLE
Don't require typing_extensions for Python 3.12+

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1246,8 +1246,8 @@ astroid = ">=3.2.4,<=3.3.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
 mccabe = ">=0.6,<0.8"
@@ -1784,4 +1784,4 @@ plot = ["matplotlib"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "6baf11cf9907661ae15984eb7aa12beb8aec40d3ef0344fb7b0a8cc03efb9c37"
+content-hash = "52d3d721ac2477f82d9edef67843ae85674baa4b07a3d9a35ceed240670902d0"

--- a/pycufsm/types.py
+++ b/pycufsm/types.py
@@ -1,7 +1,11 @@
 from typing import Any, List, Literal, Optional, Union
 
 import numpy as np
-from typing_extensions import TypedDict
+
+try:
+    from typing import TypedDict  # Python 3.12+
+except ImportError:
+    from typing_extensions import TypedDict  # Python <3.12
 
 __all__ = [
     "ArrayLike",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ matplotlib = { version = ">=3.2", optional = true }
 numpy = "==2.1.1"
 scipy = "==1.14.1"
 matplotlib = "==3.9.1"
-typing_extensions = "==4.12.2"
+typing_extensions = { version = "==4.12.2", python = "<3.12" }
 ipywidgets = "==8.1.3"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
TypedDict has been moved to the standard `typing` import

This fixes a bug in some Python 3.12+ code execution